### PR TITLE
fix:修复页脚逻辑错误

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "type": "git",
     "url": "https://github.com/JLinmr/Uptime-Status"
   },
+  "repositoryUrl": "https://github.com/JLinmr/Uptime-Status",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -67,7 +67,7 @@
       <div class="flex flex-col items-center gap-1">
         <div>
           <a 
-            :href="pkg.repository.url" 
+            :href="pkg.repositoryUrl" 
             target="_blank" 
             rel="noopener noreferrer"
             class="font-semibold hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors"
@@ -83,7 +83,7 @@
         </div>
         <div>
           Copyright © 2020 - {{ new Date().getFullYear() }} <a 
-            :href="pkg.repository.url"
+            :href="pkg.url"
             target="_blank"
             rel="noopener noreferrer"
             class="font-semibold hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors"


### PR DESCRIPTION
这个PR给`package.json`新增了`repositoryUrl`的键，值为本项目的仓库地址，用于把页脚的“[Uptime-Status](https://github.com/JLinmr/Uptime-Status) Version 1.0.0”地址固定下来。原因为：当用户修改仓库地址为自己的后，GitHub图标更换为对应链接没错，但底下的项目名称不应该更改，用于展示原作者。  
这样，用户既可以自定义状态页面为自己的信息，有保留原项目地址。