### PR TITLE
新增腾讯云 EdgeOne Pages 的 API 代理实现

### DIFF
--- a/api/status.js
+++ b/api/status.js
@@ -13,8 +13,7 @@ export class RateLimitError extends Error {
 const trim = (v) => v?.replace(/^["']|["']$/g, '').trim()
 const absUrl = (path) => path.startsWith('http') ? path : `${API}${path.startsWith('/') ? path : `/${path}`}`
 
-const keyOf = (o = {}) => trim(o.apiKey) || trim(o.api_key)
-  || trim(process.env.UPTIMEROBOT_API_KEY) || trim(process.env.VITE_UPTIMEROBOT_API_KEY)
+const keyOf = (o = {}) => trim(o.apiKey) || trim(o.api_key)  || trim(o?.env?.UPTIMEROBOT_API_KEY) || trim(o?.env?.VITE_UPTIMEROBOT_API_KEY)  || trim(process.env.UPTIMEROBOT_API_KEY) || trim(process.env.VITE_UPTIMEROBOT_API_KEY)
 
 async function get(apiKey, url) {
   const res = await fetch(url, {
@@ -88,11 +87,17 @@ export async function getCachedMonitorStatus(apiKey, { force = false } = {}) {
   return data
 }
 
-export async function parseRequestApiKey(req) {
-  const env = process.env.UPTIMEROBOT_API_KEY || process.env.VITE_UPTIMEROBOT_API_KEY
+export async function parseRequestApiKey(input) {
+  const env = keyOf(input)
   if (env) return env
-  const auth = req.headers.get('Authorization')
-  if (auth?.startsWith('Bearer ')) return auth.slice(7)
+
+  const req = input?.request ?? input
+  if (!req || typeof req !== 'object') return null
+
+  const auth = req.headers?.get?.('Authorization') ?? req.headers?.authorization
+  if (typeof auth === 'string' && auth.startsWith('Bearer ')) return auth.slice(7)
+
+  if (typeof req.url !== 'string') return null
   const q = new URL(req.url).searchParams
   return q.get('api_key') || q.get('apiKey') || null
 }

--- a/edge-functions/api/README.md
+++ b/edge-functions/api/README.md
@@ -1,6 +1,6 @@
 # API 目录说明
 
-本目录 (`functions/api/`) 包含  **Cloudflare Pages** 的 API 代理实现，对接 UptimeRobot **v3 API**。
+本目录 (`edge-functions/api/`) 包含 **腾讯云 EdgeOne Pages** 的 API 代理实现，对接 UptimeRobot **v3 API**。
 
 ## 文件说明
 
@@ -12,7 +12,7 @@
 - 处理 CORS（跨域）请求
 - 服务端缓存（5 分钟）与 429 限流响应
 
-逻辑与 `api/status.js`（Vercel 版）共用同一套实现。
+逻辑与 `api/status.js`（Cloudflare 版）共用同一套实现，但由于EdgeOne的Edge Functions只读取特定目录下的代码，特此抽离。
 
 ## 接口说明
 

--- a/edge-functions/api/status.js
+++ b/edge-functions/api/status.js
@@ -11,13 +11,15 @@ const json = (body, status = 200) => new Response(JSON.stringify(body), {
   headers: { ...corsHeaders, 'Content-Type': 'application/json', 'Cache-Control': `public, max-age=${CACHE_TTL_MS / 1000 | 0}` }
 })
 
-export async function onRequest({ request }) {
+export async function onRequest(context) {
+  const request = context?.request ?? context
+
   if (request.method === 'OPTIONS') return new Response(null, { headers: corsHeaders })
   if (request.method !== 'GET' && request.method !== 'POST') return json({ error: '只支持 GET / POST' }, 405)
 
   try {
     const url = new URL(request.url)
-    const apiKey = await parseRequestApiKey(request)
+    const apiKey = await parseRequestApiKey(context)
     const monitorId = url.searchParams.get('monitorId')
 
     if (monitorId) {

--- a/edge-functions/api/status.js
+++ b/edge-functions/api/status.js
@@ -1,0 +1,35 @@
+import {
+  getCachedMonitorStatus,
+  fetchMonitorResponseTime,
+  parseRequestApiKey,
+  corsHeaders,
+  CACHE_TTL_MS
+} from '../../api/status.js'
+
+const json = (body, status = 200) => new Response(JSON.stringify(body), {
+  status,
+  headers: { ...corsHeaders, 'Content-Type': 'application/json', 'Cache-Control': `public, max-age=${CACHE_TTL_MS / 1000 | 0}` }
+})
+
+export async function onRequest({ request }) {
+  if (request.method === 'OPTIONS') return new Response(null, { headers: corsHeaders })
+  if (request.method !== 'GET' && request.method !== 'POST') return json({ error: '只支持 GET / POST' }, 405)
+
+  try {
+    const url = new URL(request.url)
+    const apiKey = await parseRequestApiKey(request)
+    const monitorId = url.searchParams.get('monitorId')
+
+    if (monitorId) {
+      return json({ responseTimeStats: await fetchMonitorResponseTime({ apiKey, monitorId }) })
+    }
+
+    const force = ['1', 'true'].includes(url.searchParams.get('refresh'))
+    return json(await getCachedMonitorStatus(apiKey, { force }))
+  } catch (e) {
+    if (e.name === 'RateLimitError') {
+      return json({ error: e.message, retryAfter: e.retryAfter }, 429)
+    }
+    return json({ error: e.message || '请求失败' }, 500)
+  }
+}

--- a/functions/api/status.js
+++ b/functions/api/status.js
@@ -11,13 +11,15 @@ const json = (body, status = 200) => new Response(JSON.stringify(body), {
   headers: { ...corsHeaders, 'Content-Type': 'application/json', 'Cache-Control': `public, max-age=${CACHE_TTL_MS / 1000 | 0}` }
 })
 
-export async function onRequest({ request }) {
+export async function onRequest(context) {
+  const request = context?.request ?? context
+
   if (request.method === 'OPTIONS') return new Response(null, { headers: corsHeaders })
   if (request.method !== 'GET' && request.method !== 'POST') return json({ error: '只支持 GET / POST' }, 405)
 
   try {
     const url = new URL(request.url)
-    const apiKey = await parseRequestApiKey(request)
+    const apiKey = await parseRequestApiKey(context)
     const monitorId = url.searchParams.get('monitorId')
 
     if (monitorId) {

--- a/tests/edgeone-runtime.test.js
+++ b/tests/edgeone-runtime.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { parseRequestApiKey } from '../api/status.js'
+
+test('parseRequestApiKey prefers EdgeOne env values from context', async () => {
+  const result = await parseRequestApiKey({
+    env: { UPTIMEROBOT_API_KEY: 'edge-key' },
+    request: new Request('https://example.com/api/status?api_key=ignored')
+  })
+
+  assert.equal(result, 'edge-key')
+})
+
+test('parseRequestApiKey falls back to request query for standard Request objects', async () => {
+  const result = await parseRequestApiKey(new Request('https://example.com/api/status?apiKey=from-query'))
+
+  assert.equal(result, 'from-query')
+})


### PR DESCRIPTION
实现了对接 UptimeRobot v3 API 的代理功能，支持请求转发、CORS 处理及服务端缓存。提供了接口说明和环境变量配置，确保在腾讯云 EdgeOne Pages 上的顺利部署。